### PR TITLE
Added aliasing support, updated gocheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,8 @@ before_script:
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz -C ${HOME}/elasticsearch
   - ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/elasticsearch >/dev/null &
 
+install:
+  - go get gopkg.in/check.v1
+
 script:
   - make test

--- a/goes.go
+++ b/goes.go
@@ -529,15 +529,14 @@ func (c *Connection) DeleteMapping(typeName string, indexes []string) (Response,
 	return r.Run()
 }
 
-// AddAlias creates an alias to one or more indexes
-func (c *Connection) AddAlias(alias string, indexes []string) (Response, error) {
+func (c *Connection) modifyAlias(action string, alias string, indexes []string) (Response, error) {
 	command := map[string]interface{}{
 		"actions": make([]map[string]interface{}, 1),
 	}
 
 	for _, index := range indexes {
 		command["actions"] = append(command["actions"].([]map[string]interface{}), map[string]interface{}{
-			"add": map[string]interface{}{
+			action: map[string]interface{}{
 				"index": index,
 				"alias": alias,
 			},
@@ -552,4 +551,14 @@ func (c *Connection) AddAlias(alias string, indexes []string) (Response, error) 
 	}
 
 	return r.Run()
+}
+
+// AddAlias creates an alias to one or more indexes
+func (c *Connection) AddAlias(alias string, indexes []string) (Response, error) {
+	return c.modifyAlias("add", alias, indexes)
+}
+
+// RemoveAlias removes an alias to one or more indexes
+func (c *Connection) RemoveAlias(alias string, indexes []string) (Response, error) {
+	return c.modifyAlias("remove", alias, indexes)
 }

--- a/goes.go
+++ b/goes.go
@@ -562,3 +562,17 @@ func (c *Connection) AddAlias(alias string, indexes []string) (Response, error) 
 func (c *Connection) RemoveAlias(alias string, indexes []string) (Response, error) {
 	return c.modifyAlias("remove", alias, indexes)
 }
+
+// AliasExists checks whether alias is defined on the server
+func (c *Connection) AliasExists(alias string) (bool, error) {
+
+	r := Request{
+		Conn:   c,
+		method: "HEAD",
+		api:    "_alias/" + alias,
+	}
+
+	resp, err := r.Run()
+
+	return resp.Status == 200, err
+}

--- a/goes.go
+++ b/goes.go
@@ -528,3 +528,28 @@ func (c *Connection) DeleteMapping(typeName string, indexes []string) (Response,
 
 	return r.Run()
 }
+
+// AddAlias creates an alias to one or more indexes
+func (c *Connection) AddAlias(alias string, indexes []string) (Response, error) {
+	command := map[string]interface{}{
+		"actions": make([]map[string]interface{}, 1),
+	}
+
+	for _, index := range indexes {
+		command["actions"] = append(command["actions"].([]map[string]interface{}), map[string]interface{}{
+			"add": map[string]interface{}{
+				"index": index,
+				"alias": alias,
+			},
+		})
+	}
+
+	r := Request{
+		Conn:   c,
+		Query:  command,
+		method: "POST",
+		api:    "_aliases",
+	}
+
+	return r.Run()
+}

--- a/goes_test.go
+++ b/goes_test.go
@@ -1363,3 +1363,28 @@ func (s *GoesTestSuite) TestRemoveAlias(c *C) {
 	_, err = conn.Get(aliasName, docType, docId, url.Values{})
 	c.Assert(err.Error(), Equals, "[404] IndexMissingException[["+aliasName+"] missing]")
 }
+
+func (s *GoesTestSuite) TestAliasExists(c *C) {
+	index := "testaliasexist_1"
+	alias := "testaliasexists"
+
+	conn := NewConnection(ES_HOST, ES_PORT)
+	// just in case
+	conn.DeleteIndex(index)
+
+	exists, err := conn.AliasExists(alias)
+	c.Assert(exists, Equals, false)
+
+	_, err = conn.CreateIndex(index, map[string]interface{}{})
+	c.Assert(err, IsNil)
+	defer conn.DeleteIndex(index)
+	time.Sleep(200 * time.Millisecond)
+
+	_, err = conn.AddAlias(alias, []string{index})
+	c.Assert(err, IsNil)
+	time.Sleep(200 * time.Millisecond)
+	defer conn.RemoveAlias(alias, []string{index})
+
+	exists, err = conn.AliasExists(alias)
+	c.Assert(exists, Equals, true)
+}

--- a/goes_test.go
+++ b/goes_test.go
@@ -5,7 +5,7 @@
 package goes
 
 import (
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 	"net/http"
 	"net/url"
 	"os"

--- a/goes_test.go
+++ b/goes_test.go
@@ -1321,3 +1321,44 @@ func (s *GoesTestSuite) TestAddAlias(c *C) {
 	response.Raw = nil
 	c.Assert(response, DeepEquals, expectedResponse)
 }
+
+func (s *GoesTestSuite) TestRemoveAlias(c *C) {
+	aliasName := "testAlias"
+	indexName := "testalias_1"
+	docType := "testDoc"
+	docId := "1234"
+	source := map[string]interface{}{
+		"user":    "foo",
+		"message": "bar",
+	}
+
+	conn := NewConnection(ES_HOST, ES_PORT)
+	defer conn.DeleteIndex(indexName)
+
+	_, err := conn.CreateIndex(indexName, map[string]interface{}{})
+	c.Assert(err, IsNil)
+	defer conn.DeleteIndex(indexName)
+
+	d := Document{
+		Index:  indexName,
+		Type:   docType,
+		Id:     docId,
+		Fields: source,
+	}
+
+	// Index data
+	_, err = conn.Index(d, url.Values{})
+	c.Assert(err, IsNil)
+
+	// Add alias
+	_, err = conn.AddAlias(aliasName, []string{indexName})
+	c.Assert(err, IsNil)
+
+	// Remove alias
+	_, err = conn.RemoveAlias(aliasName, []string{indexName})
+	c.Assert(err, IsNil)
+
+	// Get document via alias
+	_, err = conn.Get(aliasName, docType, docId, url.Values{})
+	c.Assert(err.Error(), Equals, "[404] IndexMissingException[["+aliasName+"] missing]")
+}

--- a/goes_test.go
+++ b/goes_test.go
@@ -240,6 +240,7 @@ func (s *GoesTestSuite) TestBulkSend(c *C) {
 
 	conn := NewConnection(ES_HOST, ES_PORT)
 
+	conn.DeleteIndex(indexName)
 	_, err := conn.CreateIndex(indexName, nil)
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
Added support for add/remove aliases per API http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-aliases.html
Also updated gocheck to use updated package location https://labix.org/gocheck