### PR TITLE
Call _refresh to ensure index is refreshed before getting the status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - mkdir ${HOME}/elasticsearch
   - wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz -C ${HOME}/elasticsearch
-  - echo 'script.groovy.sandbox.enabled: true' >> ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/config/elasticsearch.yml
+  - "echo 'script.groovy.sandbox.enabled: true' >> ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/config/elasticsearch.yml"
   - ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/elasticsearch >/dev/null &
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_script:
   - wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz -C ${HOME}/elasticsearch
   - "echo 'script.groovy.sandbox.enabled: true' >> ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/config/elasticsearch.yml"
+  - 'if [ "${ES_VERSION}" < "1.3" ]; then ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/plugin --install lang-groovy; fi'
   - ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/elasticsearch >/dev/null &
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz -C ${HOME}/elasticsearch
   - "echo 'script.groovy.sandbox.enabled: true' >> ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/config/elasticsearch.yml"
-  - 'if [ "${ES_VERSION}" < "1.3" ]; then ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/plugin --install lang-groovy; fi'
+  - 'if [[ "${ES_VERSION}" < "1.3" ]]; then ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/plugin --install lang-groovy; fi'
   - ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/elasticsearch >/dev/null &
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
   - mkdir ${HOME}/elasticsearch
   - wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz -C ${HOME}/elasticsearch
+  - echo 'script.groovy.sandbox.enabled: true' >> ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/config/elasticsearch.yml
   - ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/elasticsearch >/dev/null &
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - 1.1
   - 1.2
   - 1.3
+  - 1.4.2
   - tip
 
 env:
@@ -11,10 +12,14 @@ env:
     - ES_VERSION=1.0.3
     - ES_VERSION=1.1.2
     - ES_VERSION=1.2.1
+    - ES_VERSION=1.3.4
+    - ES_VERSION=1.4.4
+    - ES_VERSION=1.5.2
+    - ES_VERSION=1.6.0
 
 before_script:
   - mkdir ${HOME}/elasticsearch
-  - wget http://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+  - wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-{ES_VERSION}.tar.gz
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz -C ${HOME}/elasticsearch
   - ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/elasticsearch >/dev/null &
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ go:
 
 env:
   matrix:
-    - ES_VERSION=1.0.3
-    - ES_VERSION=1.1.2
-    - ES_VERSION=1.2.1
+    - ES_VERSION=1.0.3 GROOVY_VER=2.0.0
+    - ES_VERSION=1.1.2 GROOVY_VER=2.0.0
+    - ES_VERSION=1.2.1 GROOVY_VER=2.2.0
     - ES_VERSION=1.3.4
     - ES_VERSION=1.4.4
     - ES_VERSION=1.5.2
@@ -22,7 +22,7 @@ before_script:
   - wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz -C ${HOME}/elasticsearch
   - "echo 'script.groovy.sandbox.enabled: true' >> ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/config/elasticsearch.yml"
-  - 'if [[ "${ES_VERSION}" < "1.3" ]]; then ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/plugin --install lang-groovy; fi'
+  - 'if [[ "${ES_VERSION}" < "1.3" ]]; then ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/plugin --install elasticsearch/elasticsearch-lang-groovy/${GROOVY_VER}; fi'
   - ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/elasticsearch >/dev/null &
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 
 before_script:
   - mkdir ${HOME}/elasticsearch
-  - wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-{ES_VERSION}.tar.gz
+  - wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz -C ${HOME}/elasticsearch
   - ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/elasticsearch >/dev/null &
 

--- a/goes_test.go
+++ b/goes_test.go
@@ -799,9 +799,11 @@ func (s *GoesTestSuite) TestIndexStatus(c *C) {
 
 	primarySizeInBytes := response.Indices[indexName].Index["primary_size_in_bytes"].(float64)
 	sizeInBytes := response.Indices[indexName].Index["size_in_bytes"].(float64)
+	refreshTotal := response.Indices[indexName].Refresh["total"].(float64)
 
 	c.Assert(primarySizeInBytes > 0, Equals, true)
 	c.Assert(sizeInBytes > 0, Equals, true)
+	c.Assert(refreshTotal > 0, Equals, true)
 
 	expectedIndices := map[string]IndexStatus{
 		indexName: {
@@ -827,7 +829,7 @@ func (s *GoesTestSuite) TestIndexStatus(c *C) {
 				"total_size_in_bytes":   float64(0),
 			},
 			Refresh: map[string]interface{}{
-				"total":                float64(1),
+				"total":                refreshTotal,
 				"total_time_in_millis": float64(0),
 			},
 			Flush: map[string]interface{}{

--- a/goes_test.go
+++ b/goes_test.go
@@ -1159,6 +1159,7 @@ func (s *GoesTestSuite) TestUpdate(c *C) {
 	// Now that we have an ordinary document indexed, try updating it
 	query := map[string]interface{}{
 		"script": "ctx._source.counter += count",
+		"lang":   "groovy",
 		"params": map[string]interface{}{
 			"count": 5,
 		},
@@ -1170,7 +1171,7 @@ func (s *GoesTestSuite) TestUpdate(c *C) {
 	}
 
 	response, err = conn.Update(d, query, extraArgs)
-	if err != nil && strings.Contains(err.(*SearchError).Msg, "dynamic scripting disabled") {
+	if err != nil && strings.Contains(err.(*SearchError).Msg, "dynamic scripting") {
 		c.Skip("Scripting is disabled on server, skipping this test")
 		return
 	}

--- a/goes_test.go
+++ b/goes_test.go
@@ -5,13 +5,14 @@
 package goes
 
 import (
-	. "gopkg.in/check.v1"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	. "gopkg.in/check.v1"
 )
 
 var (
@@ -787,6 +788,8 @@ func (s *GoesTestSuite) TestIndexStatus(c *C) {
 
 	// gives ES some time to do its job
 	time.Sleep(1 * time.Second)
+	_, err = conn.RefreshIndex(indexName)
+	c.Assert(err, IsNil)
 
 	response, err := conn.IndexStatus([]string{"testindexstatus"})
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Without this call to RefreshIndex added, TestIndexStatus was failing for me because the refresh total was coming back as 0. Using ElasticSearch 1.5.1.

```
----------------------------------------------------------------------
FAIL: goes_test.go:773: GoesTestSuite.TestIndexStatus

goes_test.go:838:
    c.Assert(response.Indices, DeepEquals, expectedIndices)
... obtained map[string]goes.IndexStatus = map[string]goes.IndexStatus{"testindexstatus":goes.IndexStatus{Index:map[string]interface {}{"primary_size_in_bytes":115, "size_in_bytes":115}, Translog:map[string]uint64{"operations":0x0}, Docs:map[string]uint64{"deleted_docs":0x0, "num_docs":0x0, "max_doc":0x0}, Merges:map[string]interface {}{"total":0, "total_time_in_millis":0, "total_docs":0, "total_size_in_bytes":0, "current":0, "current_docs":0, "current_size_in_bytes":0}, Refresh:map[string]interface {}{"total":0, "total_time_in_millis":0}, Flush:map[string]interface {}{"total":0, "total_time_in_millis":0}}}
... expected map[string]goes.IndexStatus = map[string]goes.IndexStatus{"testindexstatus":goes.IndexStatus{Index:map[string]interface {}{"size_in_bytes":115, "primary_size_in_bytes":115}, Translog:map[string]uint64{"operations":0x0}, Docs:map[string]uint64{"num_docs":0x0, "max_doc":0x0, "deleted_docs":0x0}, Merges:map[string]interface {}{"current_docs":0, "current_size_in_bytes":0, "total":0, "total_time_in_millis":0, "total_docs":0, "total_size_in_bytes":0, "current":0}, Refresh:map[string]interface {}{"total":1, "total_time_in_millis":0}, Flush:map[string]interface {}{"total":0, "total_time_in_millis":0}}}
```